### PR TITLE
flip locations of chat bubbles

### DIFF
--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -22,14 +22,14 @@ const ButtonsContainer = styled.div`
 const BotSpeaking = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   width: 100%;
 `
 
 const UserSpeaking = styled.div`
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: flex-end;
   width: 100%;
 `
 


### PR DESCRIPTION
Usually the user is on the right side. 

I didn't test this, so I hope there's deploy previews to see if I messed it up 😹